### PR TITLE
Add address and map to site footers

### DIFF
--- a/cargolink-style.css
+++ b/cargolink-style.css
@@ -291,3 +291,19 @@ footer a:hover {
     font-size: 2rem;
   }
 }
+.direccion {
+  margin-top: 1rem;
+}
+.direccion p {
+  margin-bottom: 0.5rem;
+}
+.direccion iframe {
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+@media (max-width: 768px) {
+  .direccion iframe {
+    height: 150px;
+  }
+}

--- a/gracias.html
+++ b/gracias.html
@@ -60,6 +60,10 @@
   <footer>
     <p>&copy; 2025 CargoLink. Todos los derechos reservados.</p>
     <p>Contacto: <a href="tel:+56995602717" style="color:#fff; text-decoration: underline;">+56 9 9560 2717</a> | <a href="mailto:contacto@cargolink.cl" style="color:#fff; text-decoration: underline;">contacto@cargolink.cl</a></p>
-  </footer>
+    <div class="direccion">
+    <p>Av. Falsa 123, Ciudad Imaginaria</p>
+    <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-70.68%2C-33.46%2C-70.66%2C-33.44&layer=mapnik&marker=-33.45%2C-70.67" width="100%" height="200" style="border:1px solid #ccc;"></iframe>
+  </div>
+</footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -210,6 +210,10 @@
       <a href="mailto:contacto@cargolink.cl" title="Correo"><img src="https://cdn-icons-png.flaticon.com/512/732/732200.png" /></a>
       <a href="https://wa.me/56995602717" target="_blank" title="WhatsApp"><img src="https://cdn-icons-png.flaticon.com/512/733/733585.png" /></a>
     </div>
-  </footer>
+    <div class="direccion">
+    <p>Av. Falsa 123, Ciudad Imaginaria</p>
+    <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-70.68%2C-33.46%2C-70.66%2C-33.44&layer=mapnik&marker=-33.45%2C-70.67" width="100%" height="200" style="border:1px solid #ccc;"></iframe>
+  </div>
+</footer>
 </body>
 </html>

--- a/ofertas.html
+++ b/ofertas.html
@@ -36,7 +36,11 @@
 
   <footer>
     <p>&copy; 2025 CargoLink. Todos los derechos reservados.</p>
-  </footer>
+    <div class="direccion">
+    <p>Av. Falsa 123, Ciudad Imaginaria</p>
+    <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-70.68%2C-33.46%2C-70.66%2C-33.44&layer=mapnik&marker=-33.45%2C-70.67" width="100%" height="200" style="border:1px solid #ccc;"></iframe>
+  </div>
+</footer>
   <script src="cargolink-ofertas.js"></script>
 </body>
 </html>

--- a/registro.html
+++ b/registro.html
@@ -55,6 +55,10 @@
   <footer>
     <p>&copy; 2025 CargoLink. Todos los derechos reservados.</p>
     <p>Contacto: <a href="tel:+56995602717" style="color:#fff; text-decoration: underline;">+56 9 9560 2717</a> | <a href="mailto:contacto@cargolink.cl" style="color:#fff; text-decoration: underline;">contacto@cargolink.cl</a></p>
-  </footer>
+    <div class="direccion">
+    <p>Av. Falsa 123, Ciudad Imaginaria</p>
+    <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-70.68%2C-33.46%2C-70.66%2C-33.44&layer=mapnik&marker=-33.45%2C-70.67" width="100%" height="200" style="border:1px solid #ccc;"></iframe>
+  </div>
+</footer>
 </body>
 </html>

--- a/tarifas.html
+++ b/tarifas.html
@@ -69,6 +69,10 @@
 
   <footer>
     <p>&copy; 2025 CargoLink. Todos los derechos reservados.</p>
-  </footer>
+    <div class="direccion">
+    <p>Av. Falsa 123, Ciudad Imaginaria</p>
+    <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-70.68%2C-33.46%2C-70.66%2C-33.44&layer=mapnik&marker=-33.45%2C-70.67" width="100%" height="200" style="border:1px solid #ccc;"></iframe>
+  </div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a placeholder address and embed a map in every page footer
- add styles for the new address section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483cda61b883209f0ab40c3defca1c